### PR TITLE
Fix: postprocess silently dropped outputs in workflow-author subfolders

### DIFF
--- a/tests/test_postprocess_subfolder_filename_prefix.py
+++ b/tests/test_postprocess_subfolder_filename_prefix.py
@@ -1,0 +1,142 @@
+"""Regression test: postprocess must accept outputs under a workflow-author
+subfolder (e.g. ``video/foo.mp4`` from ``filename_prefix: "video/foo"``).
+
+Earlier the defensive stale-cache guard rejected *any* path whose first
+segment under ``OUTPUT_DIR`` wasn't either top-level or the current
+request id. That silently dropped legitimate outputs of workflows that
+organise files into named subfolders, with the surface symptom
+``Processed 0 output files for <request_id>`` despite the file being
+present on disk.
+
+The fix narrows the guard so it only rejects UUID-shaped subdirectories
+that don't match the current request id (the real stale-cache case),
+and leaves arbitrary workflow-author subfolders alone.
+"""
+import os
+import uuid
+
+import pytest
+
+from workers.postprocess_worker import PostprocessWorker
+
+
+def _make_worker(tmp_path):
+    class _StubStore:
+        async def get(self, _):    return None
+        async def set(self, *_):   return None
+        async def delete(self, _): return None
+
+    w = PostprocessWorker(
+        worker_id="t",
+        kwargs={
+            "preprocess_queue":  None,
+            "generation_queue":  None,
+            "postprocess_queue": None,
+            "request_store":     _StubStore(),
+            "response_store":    _StubStore(),
+        },
+    )
+    w.output_dir = tmp_path
+    return w
+
+
+@pytest.mark.asyncio
+async def test_workflow_subfolder_is_processed(tmp_path):
+    """``SaveVideo`` with ``filename_prefix: "video/foo"`` writes to
+    ``<output>/video/foo.mp4``. ComfyUI's history correctly reports it
+    under ``images: [{filename: "foo.mp4", subfolder: "video"}]``. The
+    file must be picked up, copied into the per-request directory, and
+    returned in the result entry.
+    """
+    w = _make_worker(tmp_path)
+
+    request_id = str(uuid.uuid4())
+    job_dir = tmp_path / request_id
+    job_dir.mkdir()
+
+    subfolder_dir = tmp_path / "video"
+    subfolder_dir.mkdir()
+    src = subfolder_dir / "foo.mp4"
+    src.write_bytes(b"VIDEO")
+
+    item = {"filename": "foo.mp4", "subfolder": "video", "type": "output"}
+
+    result = await w._process_output_file(
+        item, job_output_dir=job_dir, request_id=request_id,
+        node_id="75", output_type="images",
+    )
+
+    assert result is not None, (
+        "workflow subfolder output should not be silently dropped"
+    )
+    assert result["filename"] == "foo.mp4"
+    assert result["subfolder"] == "video"
+    dest = job_dir / "foo.mp4"
+    assert dest.exists() and dest.read_bytes() == b"VIDEO"
+
+
+@pytest.mark.asyncio
+async def test_other_request_subdir_still_rejected(tmp_path):
+    """The stale-cache guard the original check was written to enforce.
+    ComfyUI returned a path whose resolved location is inside *another*
+    request's per-request directory — copying that file into ours would
+    plagiarise a prior job's output. This must still be refused.
+    """
+    w = _make_worker(tmp_path)
+
+    current_id = str(uuid.uuid4())
+    other_id   = str(uuid.uuid4())
+    assert current_id != other_id
+
+    other_dir = tmp_path / other_id
+    other_dir.mkdir()
+    real_file = other_dir / "img.png"
+    real_file.write_bytes(b"NOT MINE")
+
+    # ComfyUI's history reports the file at top-level; the wrapper
+    # symlinked it into the prior request's dir on that prior run.
+    top_link = tmp_path / "img.png"
+    os.symlink(str(real_file), str(top_link))
+
+    job_dir = tmp_path / current_id
+    job_dir.mkdir()
+
+    item = {"filename": "img.png", "subfolder": "", "type": "output"}
+
+    result = await w._process_output_file(
+        item, job_output_dir=job_dir, request_id=current_id,
+        node_id="9", output_type="images",
+    )
+
+    assert result is None, (
+        "must not copy files that resolve into another request's directory"
+    )
+    # Per-request dir stays empty — we didn't accidentally claim the file.
+    assert list(job_dir.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_self_request_subdir_is_processed(tmp_path):
+    """Sanity: a file resolved into our *own* request directory (e.g.
+    via a symlink we wrote on a prior run with the same request_id) is
+    still accepted — covered by the same-file shortcut downstream."""
+    w = _make_worker(tmp_path)
+
+    request_id = str(uuid.uuid4())
+    job_dir = tmp_path / request_id
+    job_dir.mkdir()
+    real_file = job_dir / "img.png"
+    real_file.write_bytes(b"MINE")
+
+    top_link = tmp_path / "img.png"
+    os.symlink(str(real_file), str(top_link))
+
+    item = {"filename": "img.png", "subfolder": "", "type": "output"}
+
+    result = await w._process_output_file(
+        item, job_output_dir=job_dir, request_id=request_id,
+        node_id="9", output_type="images",
+    )
+
+    assert result is not None
+    assert result["filename"] == "img.png"

--- a/workers/postprocess_worker.py
+++ b/workers/postprocess_worker.py
@@ -3,9 +3,25 @@ import asyncio
 import logging
 import os  # Still needed for symlink and remove operations
 import shutil
+import uuid
 from pathlib import Path
 from typing import Dict, List, Optional
 import json
+
+
+def _looks_like_request_id(name: str) -> bool:
+    """Return True if ``name`` matches the UUID format used for request IDs.
+
+    Used by the stale-cache guard in ``_process_output_file`` to decide
+    whether a non-self path component is "another request's directory"
+    (UUID-shaped — refuse) vs. a workflow-author subfolder convention
+    such as ``video/`` or ``images/`` (not UUID-shaped — accept).
+    """
+    try:
+        uuid.UUID(str(name))
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
 
 import aiobotocore.session
 import aiofiles
@@ -282,17 +298,21 @@ class PostprocessWorker:
             # Defensive: when ComfyUI's history points at a path that
             # has been symlinked from a previous job's directory, we'd
             # otherwise copy that prior job's file as if it were ours.
-            # Only accept sources that are top-level under OUTPUT_DIR
-            # OR that live under a subdirectory whose first segment is
-            # this request_id.
+            # Reject only when the first path segment is a UUID-shaped
+            # request id that isn't ours — that's the actual stale-cache
+            # case. Non-UUID subfolders (workflow filename_prefix
+            # conventions like ``video/`` or ``images/``) are allowed
+            # through; rejecting them silently dropped legitimate
+            # outputs of any workflow that organised files into named
+            # subfolders.
             try:
                 rel = real_original_path.relative_to(self.output_dir)
                 rel_parts = rel.parts
-                if len(rel_parts) == 1:
-                    pass
-                elif rel_parts[0] == str(request_id):
-                    pass
-                else:
+                if (
+                    len(rel_parts) > 1
+                    and _looks_like_request_id(rel_parts[0])
+                    and rel_parts[0] != str(request_id)
+                ):
                     logger.debug(f"Skipping source from different request directory: {real_original_path}")
                     return None
             except Exception:


### PR DESCRIPTION
## Problem

The defensive stale-cache guard in `postprocess_worker._process_output_file` rejected any path whose first segment under `OUTPUT_DIR` wasn't either top-level or the current request id. That silently dropped legitimate outputs from workflows that organise files into named subfolders via `filename_prefix` — e.g. a `SaveVideo` node with `filename_prefix: \"video/foo\"` writes to `output/video/foo.mp4`, ComfyUI's history correctly reports `images: [{filename: \"foo.mp4\", subfolder: \"video\"}]`, the file resolves cleanly to a real path on disk, but the guard saw `rel_parts[0] == \"video\"` (neither length-1 nor a request id) and returned `None`.

Surface symptom: `Processed 0 output files for <request_id>` in the postprocess logs while the file is plainly on disk.

## Fix

Narrow the guard so it only rejects subdirectories whose name parses as a UUID and isn't ours — i.e. the actual stale-cache case where ComfyUI's history resolves into a *different* request_id directory. Arbitrary workflow-author subfolders pass through unchanged.

```python
if (
    len(rel_parts) > 1
    and _looks_like_request_id(rel_parts[0])
    and rel_parts[0] != str(request_id)
):
    return None  # different request's directory — refuse
```

`_looks_like_request_id` uses `uuid.UUID()` parsing, which only matches the format the wrapper itself generates via `uuid.uuid4()`.

## Tests

Three new regression tests in `tests/test_postprocess_subfolder_filename_prefix.py`:

- `test_workflow_subfolder_is_processed` — `SaveVideo` writing to `output/video/foo.mp4` is picked up.
- `test_other_request_subdir_still_rejected` — preserves the original guard's intent for the actual stale-cache scenario.
- `test_self_request_subdir_is_processed` — sanity check for the same-request-id symlink case.

All 62 existing tests still pass.

## Test plan

- [x] Full pytest run green (62/62)
- [ ] Spin up a worker with a workflow using `filename_prefix: \"<subfolder>/<name>\"` and confirm output URLs are returned in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)