### PR TITLE
Fix: postprocess worker dies on missing request_store entry, draining the pool

### DIFF
--- a/tests/test_postprocess_survives_missing_request.py
+++ b/tests/test_postprocess_survives_missing_request.py
@@ -1,0 +1,154 @@
+"""Regression test: a postprocess job whose ``request_store`` entry has
+disappeared between queue insertion and processing must not crash the
+worker.
+
+Failure mode this guards against (observed live, May 2026):
+
+    ERROR:workers.postprocess_worker:PostprocessWorker N failed job X:
+        Request X not found in store
+    ERROR:asyncio:Task exception was never retrieved
+        File "workers/postprocess_worker.py", line 124, in work
+            webhook_config = await self.get_webhook_config(request.input)
+                                                            ^^^^^^^^^^^^^
+        AttributeError: 'NoneType' object has no attribute 'input'
+
+The `try` block raises a clean ``"not found in store"`` exception; the
+`except` logs it; then the `finally` dereferenced ``request.input``
+unconditionally and the AttributeError propagated out of ``work()``'s
+``while True`` loop. Each such crash removed one worker from the
+``asyncio.gather`` pool with no auto-restart — after enough crashes
+the postprocess queue had zero consumers and every subsequent request
+hung forever waiting for a "completed" status.
+
+The fix gates the webhook block on ``request is not None`` and wraps
+it in its own try/except so any unexpected error stays inside the
+loop iteration.
+"""
+import asyncio
+
+import pytest
+
+from workers.postprocess_worker import PostprocessWorker
+
+
+class _FakeRequestStore:
+    """request_store.get returns None — simulates a deleted entry."""
+    async def get(self, _):    return None
+    async def set(self, *_):   return None
+    async def delete(self, _): return None
+
+
+class _FakeResponseStore:
+    """response_store also empty — both ``request`` and ``result`` are None
+    when the worker enters its except/finally."""
+    async def get(self, _):    return None
+    async def set(self, *_):   return None
+    async def delete(self, _): return None
+
+
+def _make_worker(tmp_path, queue):
+    w = PostprocessWorker(
+        worker_id="t",
+        kwargs={
+            "preprocess_queue":  None,
+            "generation_queue":  None,
+            "postprocess_queue": queue,
+            "request_store":     _FakeRequestStore(),
+            "response_store":    _FakeResponseStore(),
+        },
+    )
+    w.output_dir = tmp_path
+    return w
+
+
+@pytest.mark.asyncio
+async def test_worker_survives_missing_request_store_entry(tmp_path):
+    """Drive ``work()`` through one job whose stores are empty, then a
+    sentinel ``None`` to terminate the loop. The worker must complete
+    the loop without the AttributeError that previously escaped from
+    the ``finally`` block."""
+    queue = asyncio.Queue()
+    await queue.put("missing-job")
+    await queue.put(None)  # shutdown sentinel
+
+    worker = _make_worker(tmp_path, queue)
+
+    # If the bug regresses, this raises AttributeError instead of
+    # returning normally.
+    await asyncio.wait_for(worker.work(), timeout=2.0)
+
+    assert queue.empty(), "queue should be drained after orderly shutdown"
+
+
+@pytest.mark.asyncio
+async def test_worker_keeps_processing_after_missing_request(tmp_path):
+    """The cascade in production: one missing-store job followed by a
+    real one. The real one must still be picked up — i.e. the worker
+    keeps consuming the queue rather than dying after the first
+    AttributeError."""
+    processed = []
+
+    class _RealRequestStore:
+        """First lookup returns None (simulates the cleanup race),
+        second returns a stub object so the second job runs normally."""
+        def __init__(self):
+            self._calls = 0
+
+        async def get(self, _):
+            self._calls += 1
+            if self._calls == 1:
+                return None
+            return _StubRequest()
+
+        async def set(self, *_):    return None
+        async def delete(self, _):  return None
+
+    class _StubRequest:
+        class _Input:
+            request_id = "ok-job"
+            return_outputs_as_base64 = False
+        input = _Input()
+
+    class _RealResponseStore:
+        def __init__(self):
+            self._calls = 0
+
+        async def get(self, _):
+            self._calls += 1
+            if self._calls <= 2:  # first job's two get() calls
+                return None
+            r = type("R", (), {})()
+            r.status = "generated"
+            r.message = ""
+            r.comfyui_response = None
+            r.output = []
+            return r
+
+        async def set(self, request_id, result):
+            processed.append(request_id)
+
+        async def delete(self, _): return None
+
+    queue = asyncio.Queue()
+    await queue.put("missing-job")
+    await queue.put("ok-job")
+    await queue.put(None)
+
+    w = PostprocessWorker(
+        worker_id="t",
+        kwargs={
+            "preprocess_queue":  None,
+            "generation_queue":  None,
+            "postprocess_queue": queue,
+            "request_store":     _RealRequestStore(),
+            "response_store":    _RealResponseStore(),
+        },
+    )
+    w.output_dir = tmp_path
+
+    await asyncio.wait_for(w.work(), timeout=2.0)
+
+    assert "ok-job" in processed, (
+        "worker should still process the second job after the first "
+        "had a missing request_store entry"
+    )

--- a/workers/postprocess_worker.py
+++ b/workers/postprocess_worker.py
@@ -59,7 +59,12 @@ class PostprocessWorker:
 
             # Process the job
             logger.info(f"PostprocessWorker {self.worker_id} processing job: {request_id}")
-            
+
+            # Pre-initialise so the `finally` block below never sees an
+            # unbound name if `request_store.get` itself raises.
+            request = None
+            result = None
+
             try:
                 # Get request and result from stores
                 request = await self.request_store.get(request_id)
@@ -120,21 +125,50 @@ class PostprocessWorker:
                     logger.error(f"Failed to update result store for {request_id}: {store_error}")
             
             finally:
-                # Handle webhook - check payload first, then environment variables
-                webhook_config = await self.get_webhook_config(request.input)
-                if webhook_config:
-                    try:
-                        await self.send_webhook(
-                            webhook_config['url'],
-                            result,
-                            webhook_config.get('extra_params', {}),
-                            secret=webhook_config.get('secret', ''),
+                # Webhook dispatch is best-effort and MUST NOT escape
+                # this block. An unhandled exception here propagates
+                # out of `work()`'s `while True` loop and removes this
+                # worker from the asyncio.gather pool with no auto-
+                # restart. After enough such crashes the postprocess
+                # queue has no consumers and every subsequent request
+                # hangs forever.
+                #
+                # Two cases this guards against:
+                #   1. `request` is None — request_store had no entry
+                #      (e.g. a duplicate postprocess_queue entry, or a
+                #      cleanup race). Without the None check, the
+                #      original code dereferenced `request.input` and
+                #      crashed the worker.
+                #   2. `get_webhook_config` itself raises — defence in
+                #      depth so a future bug in config resolution
+                #      can't kill the pool the same way.
+                try:
+                    if request is not None:
+                        webhook_config = await self.get_webhook_config(request.input)
+                        if webhook_config:
+                            try:
+                                await self.send_webhook(
+                                    webhook_config['url'],
+                                    result,
+                                    webhook_config.get('extra_params', {}),
+                                    secret=webhook_config.get('secret', ''),
+                                )
+                            except Exception as webhook_error:
+                                # Will not mark a 'completed' job as failed
+                                logger.error(f"Failed to run webhook for {request_id}: {webhook_error}")
+                        else:
+                            logger.info(f"No webhook configuration found for {request_id}")
+                    else:
+                        logger.debug(
+                            f"No request data for {request_id}; "
+                            f"skipping webhook dispatch"
                         )
-                    except Exception as webhook_error:
-                        # Will not mark a 'completed' job job as failed
-                        logger.error(f"Failed to run webhook for {request_id}: {webhook_error}")
-                else:
-                    logger.info(f"No webhook configuration found for {request_id}")
+                except Exception as finally_error:
+                    logger.exception(
+                        f"Unexpected error in postprocess finally for {request_id}: "
+                        f"{finally_error}"
+                    )
+
                 # Clean up the request store
                 try:
                     await self.request_store.delete(request_id)


### PR DESCRIPTION
## Symptom (production)

Generation logs look healthy:

\`\`\`
INFO:workers.generation_worker:GenerationWorker 1 completed job: <uuid>
\`\`\`

…then nothing. No \`PostprocessWorker N processing job\`. \`/generate/sync\` never returns to the client; the request hangs until the connection times out. Subsequent requests have the same fate.

## Root cause

When \`request_store.get(request_id)\` returns \`None\` (duplicate queue entry, redis eviction, cleanup race), the per-job \`try\` block raises a clean \`"Request not found in store"\` exception and the \`except\` logs it. But the \`finally\` then dereferenced \`request.input\` unconditionally:

\`\`\`python
finally:
    webhook_config = await self.get_webhook_config(request.input)
\`\`\`

\`AttributeError: 'NoneType' object has no attribute 'input'\` escapes \`work()\`'s \`while True\` loop with no enclosing handler. There is no auto-restart for tasks inside the \`asyncio.gather\` pool — that worker is gone for the lifetime of the api-wrapper process. Each subsequent crash drains the pool by one. With both postprocess workers dead, the queue has zero consumers and everything queued from then on hangs.

Live trace (excerpt):

\`\`\`
ERROR:workers.postprocess_worker:PostprocessWorker 2 failed job test-63927: Request test-63927 not found in store
ERROR:main:Worker task failed: 'NoneType' object has no attribute 'input'
ERROR:asyncio:Task exception was never retrieved
  File "workers/postprocess_worker.py", line 124, in work
      webhook_config = await self.get_webhook_config(request.input)
                                                      ^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'input'
\`\`\`

## Fix

- **Pre-initialise** \`request\` and \`result\` to \`None\` before the \`try\` so the \`finally\` block never sees an unbound name even if the store calls themselves raise.
- **Gate the webhook block on \`request is not None\`** — the actual bug.
- **Wrap the whole webhook block in its own try/except** as defence in depth, so any future bug in \`get_webhook_config\`/\`send_webhook\` setup stays inside the loop iteration instead of killing the worker.

## Tests

Two regression tests in \`tests/test_postprocess_survives_missing_request.py\`:

- \`test_worker_survives_missing_request_store_entry\` — drives \`work()\` through one job whose stores return \`None\`, then a shutdown sentinel. Without the fix this raises \`AttributeError\` from \`finally\`. With the fix the loop exits cleanly.
- \`test_worker_keeps_processing_after_missing_request\` — head of queue is missing-store, follow-up is real. Without the fix the second job is never picked up. With the fix it is.

Both tests verified to fail without the patch and pass with it. Full suite: 64/64 green.

## Test plan

- [x] Both new tests genuinely reproduce the production crash without the fix
- [x] Full pytest run still green
- [ ] Verify on the live test instance: trigger the missing-store scenario (e.g. duplicate \`postprocess_queue\` entry) and confirm the worker stays alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)