### PR TITLE
Fix: postprocess silently drops cache-hit outputs that resolve into a prior request's dir

### DIFF
--- a/tests/test_postprocess_subfolder_filename_prefix.py
+++ b/tests/test_postprocess_subfolder_filename_prefix.py
@@ -1,16 +1,24 @@
-"""Regression test: postprocess must accept outputs under a workflow-author
-subfolder (e.g. ``video/foo.mp4`` from ``filename_prefix: "video/foo"``).
+"""Regression tests for postprocess output discovery.
 
-Earlier the defensive stale-cache guard rejected *any* path whose first
-segment under ``OUTPUT_DIR`` wasn't either top-level or the current
-request id. That silently dropped legitimate outputs of workflows that
-organise files into named subfolders, with the surface symptom
-``Processed 0 output files for <request_id>`` despite the file being
-present on disk.
+Two failure modes both surface as ``Processed 0 output files for
+<request_id>`` despite the file being on disk:
 
-The fix narrows the guard so it only rejects UUID-shaped subdirectories
-that don't match the current request id (the real stale-cache case),
-and leaves arbitrary workflow-author subfolders alone.
+1. Workflow-author subfolders (``SaveVideo`` with ``filename_prefix:
+   "video/foo"`` writes to ``output/video/foo.mp4``) used to be
+   silently dropped because an over-eager defensive guard refused
+   anything outside the top-level or the current request's
+   per-request directory.
+
+2. Cache hits on a previously-seen prompt resolve into the *prior*
+   request's per-request directory (that's where postprocess copied
+   the file on the original run, and the top-level symlink still
+   points there). The same defensive guard refused those too.
+
+Both were the same broken assumption: "anything not under the current
+request's directory is stale". In reality the stale-cache concern
+doesn't exist — ComfyUI's history is the source of truth for which
+file belongs to this job, and we should copy whatever it points at
+into our per-request directory.
 """
 import os
 import uuid
@@ -76,11 +84,19 @@ async def test_workflow_subfolder_is_processed(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_other_request_subdir_still_rejected(tmp_path):
-    """The stale-cache guard the original check was written to enforce.
-    ComfyUI returned a path whose resolved location is inside *another*
-    request's per-request directory — copying that file into ours would
-    plagiarise a prior job's output. This must still be refused.
+async def test_cache_hit_resolving_into_prior_request_subdir(tmp_path):
+    """Cache hit on the same prompt as a prior job: ComfyUI's history
+    reports the same filename, the top-level entry is a symlink into
+    the prior request's per-request directory (where the wrapper
+    parked the file on the original run), and the resolved real path
+    therefore lives under another UUID-shaped subdirectory.
+
+    This is **not** stale data — it's the same prompt's output, which
+    is the whole point of ComfyUI's prompt cache. The wrapper must
+    accept it and copy it into the current request's directory rather
+    than silently dropping it (which is what an earlier over-eager
+    "different request directory" guard did, surfacing as
+    ``Processed 0 output files`` for every cache hit beyond the first).
     """
     w = _make_worker(tmp_path)
 
@@ -88,13 +104,14 @@ async def test_other_request_subdir_still_rejected(tmp_path):
     other_id   = str(uuid.uuid4())
     assert current_id != other_id
 
+    # Prior run's per-request directory holds the actual file.
     other_dir = tmp_path / other_id
     other_dir.mkdir()
     real_file = other_dir / "img.png"
-    real_file.write_bytes(b"NOT MINE")
+    real_file.write_bytes(b"CACHED")
 
-    # ComfyUI's history reports the file at top-level; the wrapper
-    # symlinked it into the prior request's dir on that prior run.
+    # Top-level entry is a symlink into that directory — what
+    # postprocess wrote on the prior run.
     top_link = tmp_path / "img.png"
     os.symlink(str(real_file), str(top_link))
 
@@ -108,11 +125,13 @@ async def test_other_request_subdir_still_rejected(tmp_path):
         node_id="9", output_type="images",
     )
 
-    assert result is None, (
-        "must not copy files that resolve into another request's directory"
+    assert result is not None, (
+        "cache-hit output must not be dropped just because it resolves "
+        "into another request's per-request directory"
     )
-    # Per-request dir stays empty — we didn't accidentally claim the file.
-    assert list(job_dir.iterdir()) == []
+    assert result["filename"] == "img.png"
+    dest = job_dir / "img.png"
+    assert dest.exists() and dest.read_bytes() == b"CACHED"
 
 
 @pytest.mark.asyncio

--- a/workers/postprocess_worker.py
+++ b/workers/postprocess_worker.py
@@ -3,25 +3,9 @@ import asyncio
 import logging
 import os  # Still needed for symlink and remove operations
 import shutil
-import uuid
 from pathlib import Path
 from typing import Dict, List, Optional
 import json
-
-
-def _looks_like_request_id(name: str) -> bool:
-    """Return True if ``name`` matches the UUID format used for request IDs.
-
-    Used by the stale-cache guard in ``_process_output_file`` to decide
-    whether a non-self path component is "another request's directory"
-    (UUID-shaped — refuse) vs. a workflow-author subfolder convention
-    such as ``video/`` or ``images/`` (not UUID-shaped — accept).
-    """
-    try:
-        uuid.UUID(str(name))
-        return True
-    except (ValueError, AttributeError, TypeError):
-        return False
 
 import aiobotocore.session
 import aiofiles
@@ -326,31 +310,19 @@ class PostprocessWorker:
             # Destination path in job directory
             dest_path = job_output_dir / filename
 
-            # Get the real path (in case original_path is a symlink from a cached result)
+            # Get the real path (in case original_path is a symlink from a cached result).
+            #
+            # No "is this the right request's directory?" guard here.
+            # ComfyUI's history is the source of truth for which file
+            # belongs to this job, and a cache hit on the same prompt
+            # legitimately resolves into the *prior* request's
+            # per-request directory (that's where postprocess copied
+            # the file last time). Rejecting that path silently drops
+            # the output. We trust ComfyUI's mapping, copy whatever it
+            # points at into the current request's directory, and let
+            # the same-file shortcut below handle the unusual case
+            # where source and destination are already the same file.
             real_original_path = original_path.resolve()
-
-            # Defensive: when ComfyUI's history points at a path that
-            # has been symlinked from a previous job's directory, we'd
-            # otherwise copy that prior job's file as if it were ours.
-            # Reject only when the first path segment is a UUID-shaped
-            # request id that isn't ours — that's the actual stale-cache
-            # case. Non-UUID subfolders (workflow filename_prefix
-            # conventions like ``video/`` or ``images/``) are allowed
-            # through; rejecting them silently dropped legitimate
-            # outputs of any workflow that organised files into named
-            # subfolders.
-            try:
-                rel = real_original_path.relative_to(self.output_dir)
-                rel_parts = rel.parts
-                if (
-                    len(rel_parts) > 1
-                    and _looks_like_request_id(rel_parts[0])
-                    and rel_parts[0] != str(request_id)
-                ):
-                    logger.debug(f"Skipping source from different request directory: {real_original_path}")
-                    return None
-            except Exception:
-                pass  # not under OUTPUT_DIR — let the original path through
 
             # Same-file shortcut. When a request_id is reused AND
             # ComfyUI's prompt cache hits with the same outputs,


### PR DESCRIPTION
## Symptom (production)

First request with a given prompt: works.
Second and subsequent requests with the **same prompt**: response returns 200 OK but the per-request directory is empty and the postprocess log says \`Processed 0 output files for <request_id>\`.

## Root cause

Walked the trace on a live instance running the post-#7/#8 wrapper:

1. Request A submits prompt. ComfyUI generates \`image_00008_.png\`. Postprocess copies it into \`output/A/\` and replaces the top-level entry with a symlink \`output/image_00008_.png -> output/A/image_00008_.png\`.
2. Request B submits the **same** prompt. ComfyUI cache hit; history reports \`{filename: \"image_00008_.png\", subfolder: \"\"}\`.
3. The wrapper resolves \`output/image_00008_.png\` through the symlink and lands on \`output/A/image_00008_.png\`.
4. The defensive guard introduced in #7 sees \`rel_parts = ('A', 'image_00008_.png')\`, recognises \`A\` as a UUID different from B, and returns \`None\`.
5. Result: \`Processed 0 output files\`. Surfaces to the API client as an empty response.

## What was wrong with the guard

That guard was based on a wrong premise: I read \"resolved path lives in another UUID-shaped subdirectory\" as \"stale cache pointer from a different job\", and rejected. But that's actually the **normal** ComfyUI cache-hit shape. The cached file *is* the correct data for the same prompt — that's what caching means. Dropping it silently breaks every repeat prompt.

There is no real \"stale cache from another request\" failure mode to defend against here: ComfyUI's history is authoritative for which file belongs to this job, and that mapping doesn't lie.

## Fix

Remove the guard outright. Trust the history; copy whatever file it points at into the current request's directory. The same-file shortcut downstream still handles the case where source and destination are already the same file (covered by the existing duplicate-request-id test from #5).

The previously-added \`_looks_like_request_id\` helper was only used by the guard, so it's gone too.

## Tests

Replaced the previous \`test_other_request_subdir_still_rejected\` (which asserted the broken behavior) with \`test_cache_hit_resolving_into_prior_request_subdir\`, which encodes the production scenario: a top-level symlink pointing into a prior UUID-shaped subdirectory must result in the file being copied into the current request's directory.

Verified the new test fails on the previous version of \`postprocess_worker.py\` with the production symptom (\`assert result is not None\` → got \`None\`), and passes with this PR's fix. Full suite: 64/64 green.

The other two tests (\`test_workflow_subfolder_is_processed\`, \`test_self_request_subdir_is_processed\`) still pass unchanged — workflow-author subfolders and same-request symlinks were always meant to work.

## Test plan

- [x] New regression test reproduces the production failure without the fix
- [x] Full pytest run still green (64/64)
- [x] Existing duplicate-request-id same-file shortcut test still passes
- [ ] Verify on the live instance: pull this branch, restart the api-wrapper, submit the same prompt twice — second response should now contain the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)