### PR TITLE
Fix: /generate/sync and /result return 200 even when result.status is failed

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,6 +118,53 @@ def _apply_base64_header(request: Request, payload):
         payload.input.return_outputs_as_base64 = True
 
 
+# Substrings that classify a `failed` result.message as an upstream
+# connectivity / timeout problem (ComfyUI wasn't reachable, /prompt
+# retries exhausted, ws connection lost) rather than a generation
+# error. Not exhaustive — additions welcome as new failure modes
+# surface in production.
+_UPSTREAM_FAIL_HINTS = (
+    "cannot connect",
+    "failed to post workflow after",
+    "network error",
+    "connection refused",
+    "websocket timeout",
+    "websocket failure",
+    "timed out",
+)
+
+
+def _http_status_for(result) -> int:
+    """Map a terminal Result to the HTTP status the endpoint should send.
+
+    The polling endpoints (`/generate/sync`, `/result/...`) historically
+    returned HTTP 200 regardless of the body's `status` field — so the
+    SDK's benchmark, which keys off HTTP status code, counted a 0.5s
+    "Cannot connect to host" failure as a successful 100-workload
+    request and reported a fake very-fast worker (perf=200).
+
+    Mapping:
+      completed   -> 200
+      cancelled   -> 499  (matches the client-disconnect path elsewhere)
+      failed      -> 502  if the message points at an upstream
+                          connectivity / timeout class issue
+                     500  otherwise (generation-side error: bad
+                          workflow, OOM, etc — still a real failure
+                          but not a gateway one)
+    """
+    status = getattr(result, "status", None)
+    if status == "completed":
+        return 200
+    if status == "cancelled":
+        return 499
+    # Treat anything else (failed, malformed, missing) as a server
+    # error — better to over-report 5xx than silently lie about success.
+    msg = (getattr(result, "message", "") or "").lower()
+    if any(hint in msg for hint in _UPSTREAM_FAIL_HINTS):
+        return 502
+    return 500
+
+
 def _shape_result(result, request: "Request | None" = None):
     """Return a copy of `result` with `comfyui_response` stripped to
     `{}` unless the caller opted in.
@@ -510,6 +557,11 @@ async def generate_sync(
             while True:
                 result = await response_store.get(request_id)
                 if result and result.status in ("completed", "failed", "cancelled"):
+                    # Reflect the body's status in the HTTP code so
+                    # callers (and benchmark drivers that key off HTTP
+                    # status) can't mistake a fast failure for a fast
+                    # success.
+                    response.status_code = _http_status_for(result)
                     return _shape_result(result, request)
                 await asyncio.sleep(0.5)
 
@@ -815,7 +867,15 @@ async def result(request_id: str, request: Request, response: Response):
         if not result:
             result = Result(id=request_id, status="failed", message="Request ID not found")
             response.status_code = 404
+            return _shape_result(result, request)
 
+        # Reflect terminal status in the HTTP code so a failed /
+        # cancelled job can't be misread as a success. In-progress
+        # states (pending, generating, processing, generated) stay at
+        # 200 so polling callers can distinguish "still working" from
+        # "done with status X".
+        if result.status in ("completed", "failed", "cancelled"):
+            response.status_code = _http_status_for(result)
         return _shape_result(result, request)
     except Exception as e:
         logger.error(f"Failed to get result for {request_id}: {e}")

--- a/tests/test_http_status_for.py
+++ b/tests/test_http_status_for.py
@@ -1,0 +1,71 @@
+"""Tests for the terminal-status -> HTTP-code mapping in main.py.
+
+Background: `/generate/sync` and `/result/...` historically returned
+HTTP 200 regardless of the body's `status` field. The Vast SDK's
+benchmark counts a successful response by HTTP code, not body, so a
+fast-failing 0.5s "Cannot connect to host" reply was being scored as
+a 100-workload success — surfacing as a fake very-fast worker
+(perf=200). The fix maps terminal status to a meaningful code.
+"""
+import pytest
+
+from main import _http_status_for
+from responses.result import Result
+
+
+@pytest.mark.parametrize("message", [
+    # post_workflow's after-N-attempts message
+    "Failed to post workflow after 5 attempts: ClientConnectorError",
+    # raw aiohttp connect-failed text
+    "Cannot connect to host localhost:18188 ssl:default",
+    "Network error getting result: ConnectionResetError",
+    "Connection refused",
+    "WebSocket timeout for job abc-123",
+    "WebSocket failure mid-stream",
+    "Operation timed out after 30s",
+    # case insensitivity — match should be lower-case substring
+    "TIMED OUT WAITING",
+])
+def test_failed_with_upstream_class_returns_502(message):
+    r = Result(id="t", status="failed", message=message)
+    assert _http_status_for(r) == 502
+
+
+@pytest.mark.parametrize("message", [
+    "ComfyUI node errors: KSampler.sampler_name not in list",
+    "ComfyUI error: bad input",
+    "torch.cuda.OutOfMemoryError: CUDA out of memory",
+    "Generation failed: invalid workflow",
+    "",  # no message at all — still a real failure
+])
+def test_failed_without_upstream_class_returns_500(message):
+    r = Result(id="t", status="failed", message=message)
+    assert _http_status_for(r) == 500
+
+
+def test_completed_returns_200():
+    r = Result(id="t", status="completed", message="Processing complete.")
+    assert _http_status_for(r) == 200
+
+
+def test_cancelled_returns_499():
+    r = Result(id="t", status="cancelled", message="Request cancelled by client")
+    assert _http_status_for(r) == 499
+
+
+@pytest.mark.parametrize("status", ["pending", "generating", "processing", "generated"])
+def test_non_terminal_falls_through_to_500(status):
+    """Defensive: callers should only pass terminal results, but if
+    something slips through, return 500 so the caller doesn't read it
+    as a success. (`/result/{id}` and `/generate/sync` already gate on
+    a terminal-status check before invoking this helper.)"""
+    r = Result(id="t", status=status, message="")
+    assert _http_status_for(r) == 500
+
+
+def test_missing_status_attribute_returns_500():
+    """A bare object without `.status` should still be treated as a
+    failure, not silently mapped to 200."""
+    class Bare:
+        pass
+    assert _http_status_for(Bare()) == 500


### PR DESCRIPTION
## Symptom

A worker can ship a "passing" benchmark with \`max_perf=200\` while every actual request is failing. Trace:

\`\`\`
ERROR:workers.generation_worker:GenerationWorker 1 failed job test-6603: Network error posting to ComfyUI: Cannot connect to host localhost:18188 ...
INFO:workers.postprocess_worker:Job test-6603 already marked as failed, keeping failure status
INFO:     127.0.0.1:44808 - \"POST /generate/sync HTTP/1.1\" 200 OK
\`\`\`

The \`200 OK\` is the bug: \`/generate/sync\` was decorated \`status_code=200\` and returned bare on any terminal \`Result.status\`, so a body of \`{\"status\": \"failed\", \"message\": \"Cannot connect to host ...\"}\` still shipped as HTTP 200. The Vast SDK's benchmark counts a successful request by HTTP code, not body — so the 0.5s connection failure scored as a 100-workload success and the worker reported a fake very-fast benchmark.

Same pattern in \`/result/{request_id}\`.

## Fix

Add \`_http_status_for(result)\` mapping terminal status to a meaningful HTTP code:

| \`result.status\` | HTTP | When |
|---|---|---|
| \`completed\` | **200** | unchanged |
| \`cancelled\` | **499** | matches the existing client-disconnect path |
| \`failed\` | **502** | upstream connectivity / timeout class (Cannot connect, post-workflow retries exhausted, ws timeout, ...) |
| \`failed\` | **500** | generation-side error (bad workflow, OOM, ...) |
| anything else | **500** | defensive — caller shouldn't pass non-terminal, but if one slips through we still don't lie about success |

\`/generate/sync\` already gates on \`status in (completed, failed, cancelled)\` so it always passes a terminal value. \`/result/{request_id}\` only applies the mapping for terminal statuses — in-progress states (pending, generating, processing, generated) stay at HTTP 200 so polling clients can distinguish \"still working\" from \"done with status X\".

## Tests

\`tests/test_http_status_for.py\` — 13 parametrised cases covering each known upstream-error shape, the 500/499/200 paths, and the defensive fallthrough on non-terminal / missing status. All 84 existing tests still pass.

## Test plan

- [x] Helper covers the failure shapes seen in production logs
- [x] Full pytest run green (84/84)
- [ ] Verify on a live worker: trigger a ComfyUI-unreachable failure (e.g. kill ComfyUI mid-request), submit through \`/generate/sync\`, confirm response is HTTP 502 with the failed body — and that the SDK's benchmark counts it as failed rather than a 100-workload success

🤖 Generated with [Claude Code](https://claude.com/claude-code)