### PR TITLE
Emit BACKENDS_READY / BACKEND_UNRECOVERABLE log signals for downstream pyworkers

### DIFF
--- a/main.py
+++ b/main.py
@@ -183,11 +183,95 @@ def _shape_result(result, request: "Request | None" = None):
     return result.model_copy(update={"comfyui_response": {}})
 
 
+async def _probe_backend(urls: dict) -> dict:
+    """HTTP + WebSocket reachability probe for one ComfyUI backend.
+
+    Used by both ``/health`` (synchronous status snapshot) and the
+    startup announcer below (waits for every backend before declaring
+    readiness). Returning a dict rather than a bool keeps the
+    ``/health`` body shape stable while letting the announcer just
+    check ``http_ok and websocket_ok``.
+    """
+    info = {"base": urls["base"], "http_ok": False, "websocket_ok": False}
+    try:
+        t = aiohttp.ClientTimeout(total=5)
+        async with aiohttp.ClientSession(timeout=t) as session:
+            async with session.get(urls["system_stats"]) as r:
+                if r.status == 200:
+                    info["http_ok"] = True
+                    info["system_stats"] = await r.json()
+                else:
+                    info["http_error"] = f"system_stats returned {r.status}"
+    except aiohttp.ClientError as e:
+        info["http_error"] = f"connect failed: {e}"
+    except Exception as e:
+        info["http_error"] = f"unexpected: {e}"
+
+    try:
+        t = aiohttp.ClientTimeout(total=2.0)
+        async with aiohttp.ClientSession(timeout=t) as session:
+            async with session.ws_connect(
+                urls["websocket"], params={"clientId": "healthcheck"}
+            ) as ws:
+                info["websocket_ok"] = True
+                await ws.close()
+    except Exception as e:
+        info["websocket_error"] = f"{e}"
+
+    return info
+
+
+# Tunable for tests; production default mirrors convert-workflows.sh's
+# COMFYUI_READY_TIMEOUT so we won't park startup forever while ComfyUI
+# is still loading models.
+_BACKENDS_READY_TIMEOUT_S       = 600
+_BACKENDS_READY_POLL_INTERVAL_S = 2
+
+
+async def _announce_backends_ready() -> None:
+    """Probe every configured backend until all reach HTTP+WS ready,
+    then emit a single ``BACKENDS_READY`` log line.
+
+    Pyworkers watching the api-wrapper log key ``MODEL_LOAD_LOG_MSG``
+    off this token instead of uvicorn's ``Uvicorn running on`` —
+    that earlier line only confirms our own listener is bound, but
+    here we're confirming the full stack (api-wrapper + ComfyUI) is
+    actually serviceable, so warm-up benchmarks can't fire against a
+    half-ready pod.
+
+    On timeout we emit ``BACKENDS_READY_TIMEOUT`` so the pyworker's
+    ``MODEL_ERROR_LOG_MSGS`` can pick it up and mark the worker
+    errored rather than letting it sit indefinitely "loading".
+    """
+    deadline = time.monotonic() + _BACKENDS_READY_TIMEOUT_S
+    while time.monotonic() < deadline:
+        infos = [await _probe_backend(comfyui_urls(b)) for b in COMFYUI_BACKENDS]
+        ready = sum(1 for i in infos if i["http_ok"] and i["websocket_ok"])
+        if ready == len(COMFYUI_BACKENDS):
+            logger.info(
+                "BACKENDS_READY: %d backend(s) reachable, ready to serve",
+                len(COMFYUI_BACKENDS),
+            )
+            return
+        logger.debug(
+            "Backend readiness: %d/%d ready, retrying", ready, len(COMFYUI_BACKENDS)
+        )
+        await asyncio.sleep(_BACKENDS_READY_POLL_INTERVAL_S)
+    logger.error(
+        "BACKENDS_READY_TIMEOUT: not all of %d backend(s) reachable after %ds",
+        len(COMFYUI_BACKENDS),
+        _BACKENDS_READY_TIMEOUT_S,
+    )
+
+
 @app.on_event("startup")
 async def startup_event():
     """Initialize workers on startup"""
     try:
         asyncio.create_task(main())
+        # Backend reachability is announced separately so the pyworker
+        # can wait for the *full* stack rather than just uvicorn binding.
+        asyncio.create_task(_announce_backends_ready())
         logger.info("Workers initialized successfully")
     except Exception as e:
         logger.error(f"Failed to initialize workers: {e}")
@@ -951,43 +1035,9 @@ async def health(response: Response):
     backends_detail = []
     n_healthy = 0
 
-    async def _probe(urls: dict) -> dict:
-        """One backend's HTTP + WS probe."""
-        info = {
-            "base":         urls["base"],
-            "http_ok":      False,
-            "websocket_ok": False,
-        }
-        try:
-            t = aiohttp.ClientTimeout(total=5)
-            async with aiohttp.ClientSession(timeout=t) as session:
-                async with session.get(urls["system_stats"]) as r:
-                    if r.status == 200:
-                        info["http_ok"] = True
-                        info["system_stats"] = await r.json()
-                    else:
-                        info["http_error"] = f"system_stats returned {r.status}"
-        except aiohttp.ClientError as e:
-            info["http_error"] = f"connect failed: {e}"
-        except Exception as e:
-            info["http_error"] = f"unexpected: {e}"
-
-        try:
-            t = aiohttp.ClientTimeout(total=2.0)
-            async with aiohttp.ClientSession(timeout=t) as session:
-                async with session.ws_connect(
-                    urls["websocket"], params={"clientId": "healthcheck"}
-                ) as ws:
-                    info["websocket_ok"] = True
-                    await ws.close()
-        except Exception as e:
-            info["websocket_error"] = f"{e}"
-
-        return info
-
     for backend_url in COMFYUI_BACKENDS:
         urls = comfyui_urls(backend_url)
-        info = await _probe(urls)
+        info = await _probe_backend(urls)
         # Per-backend GPU latch.
         gpu_state = get_gpu_state(backend_url)
         info["gpu"] = gpu_state

--- a/tests/test_backends_ready_signal.py
+++ b/tests/test_backends_ready_signal.py
@@ -1,0 +1,126 @@
+"""Tests for the BACKENDS_READY / BACKENDS_READY_TIMEOUT log signals.
+
+Background: pyworkers tail the api-wrapper log to drive their warm-up
+state machine. The earlier ``Uvicorn running on …`` line only meant
+"our HTTP listener is bound" — it didn't say anything about whether
+ComfyUI behind us was actually up. Pods where ComfyUI hadn't loaded
+(or had crashed between provisioning and uvicorn binding) ran benchmark
+against an unreachable backend and the SDK's HTTP-status-only success
+check counted the resulting fast 502s as a fast worker.
+
+The wrapper now emits ``BACKENDS_READY`` only after every configured
+backend passes the same HTTP+WS probe ``/health`` uses, and
+``BACKENDS_READY_TIMEOUT`` if they don't come up within the deadline.
+"""
+import asyncio
+import logging
+
+import pytest
+
+import main
+
+
+@pytest.fixture
+def fast_announcer(monkeypatch):
+    """Tighten the announcer's loop so tests don't wait minutes."""
+    monkeypatch.setattr(main, "_BACKENDS_READY_TIMEOUT_S", 1)
+    monkeypatch.setattr(main, "_BACKENDS_READY_POLL_INTERVAL_S", 0.05)
+
+
+@pytest.fixture
+def two_backends(monkeypatch):
+    monkeypatch.setattr(main, "COMFYUI_BACKENDS", [
+        "http://backend-a:18188",
+        "http://backend-b:18188",
+    ])
+
+
+async def _probe_returning(http_ok: bool, websocket_ok: bool):
+    async def _impl(urls):
+        return {
+            "base": urls["base"],
+            "http_ok": http_ok,
+            "websocket_ok": websocket_ok,
+        }
+    return _impl
+
+
+@pytest.mark.asyncio
+async def test_emits_backends_ready_when_all_probes_pass(
+    fast_announcer, two_backends, monkeypatch, caplog
+):
+    monkeypatch.setattr(main, "_probe_backend", await _probe_returning(True, True))
+
+    with caplog.at_level(logging.INFO, logger=main.logger.name):
+        await main._announce_backends_ready()
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("BACKENDS_READY:" in m for m in msgs), msgs
+    assert not any("BACKENDS_READY_TIMEOUT" in m for m in msgs), msgs
+
+
+@pytest.mark.asyncio
+async def test_emits_timeout_when_backends_never_become_ready(
+    fast_announcer, two_backends, monkeypatch, caplog
+):
+    monkeypatch.setattr(main, "_probe_backend", await _probe_returning(False, False))
+
+    with caplog.at_level(logging.ERROR, logger=main.logger.name):
+        await main._announce_backends_ready()
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("BACKENDS_READY_TIMEOUT" in m for m in msgs), msgs
+    assert not any(m.startswith("BACKENDS_READY:") for m in msgs), msgs
+
+
+@pytest.mark.asyncio
+async def test_waits_for_late_backend_then_emits_ready(
+    fast_announcer, two_backends, monkeypatch, caplog
+):
+    """One backend is slow to come up — announcer must keep polling
+    until it does, then emit BACKENDS_READY exactly once."""
+    calls = {"n": 0}
+
+    async def _probe(urls):
+        calls["n"] += 1
+        # First two probe rounds (4 calls for 2 backends): backend-b
+        # is down. After that, both up.
+        backend_b_down = calls["n"] <= 4 and "backend-b" in urls["base"]
+        return {
+            "base":         urls["base"],
+            "http_ok":      not backend_b_down,
+            "websocket_ok": not backend_b_down,
+        }
+
+    monkeypatch.setattr(main, "_probe_backend", _probe)
+
+    with caplog.at_level(logging.INFO, logger=main.logger.name):
+        await main._announce_backends_ready()
+
+    msgs = [r.getMessage() for r in caplog.records]
+    ready = [m for m in msgs if "BACKENDS_READY:" in m and "TIMEOUT" not in m]
+    assert len(ready) == 1, f"expected exactly one ready announcement, got {ready}"
+
+
+def test_unrecoverable_log_carries_grep_token():
+    """The pyworker matches MODEL_ERROR_LOG_MSGS as a substring; the
+    fatal log line must contain BACKEND_UNRECOVERABLE so a fault
+    reaches the autoscaler instead of stalling silently."""
+    from workers.generation_worker import mark_gpu_unrecoverable, _GPU_STATE
+    _GPU_STATE.clear()
+    import logging as _l
+    rec = []
+
+    class _H(_l.Handler):
+        def emit(self, r):
+            rec.append(r.getMessage())
+
+    h = _H()
+    _l.getLogger("workers.generation_worker").addHandler(h)
+    try:
+        mark_gpu_unrecoverable("http://b:18188", "device-side assert")
+    finally:
+        _l.getLogger("workers.generation_worker").removeHandler(h)
+        _GPU_STATE.clear()
+
+    assert any("BACKEND_UNRECOVERABLE" in m for m in rec), rec

--- a/workers/generation_worker.py
+++ b/workers/generation_worker.py
@@ -38,12 +38,18 @@ _GPU_STATE: Dict[str, Dict[str, Any]] = {}
 def mark_gpu_unrecoverable(backend_url: str, reason: str) -> None:
     """Latch the GPU-unrecoverable flag for `backend_url`. Idempotent
     per backend — preserves the first reason recorded so the operator
-    sees the originating fault rather than a downstream one."""
+    sees the originating fault rather than a downstream one.
+
+    The log line carries the ``BACKEND_UNRECOVERABLE`` token so any
+    pyworker tailing this log can match it via
+    ``MODEL_ERROR_LOG_MSGS`` and propagate the failure upstream
+    instead of waiting indefinitely for a recovery that won't come.
+    """
     state = _GPU_STATE.setdefault(backend_url, {"unrecoverable": False, "reason": ""})
     if not state["unrecoverable"]:
         state["unrecoverable"] = True
         state["reason"] = reason or "unspecified"
-        logger.error(f"GPU on {backend_url} latched as unrecoverable: {reason}")
+        logger.error(f"BACKEND_UNRECOVERABLE: GPU on {backend_url} latched: {reason}")
 
 
 def get_gpu_state(backend_url: Optional[str] = None) -> Dict[str, Any]:


### PR DESCRIPTION
## Why

Pyworkers tail this log to drive their warm-up state machine. The handles they had were both indirect:

- ``MODEL_LOAD_LOG_MSG = \"Uvicorn running on\"`` — fires when *our* HTTP listener binds, before we've ever asked ComfyUI whether it's reachable. Pods where ComfyUI hadn't loaded (or had crashed between provisioning and uvicorn binding) saw the pyworker run benchmark immediately, every request fail with \"Cannot connect to host localhost:18188\", and the Vast SDK score the resulting fast 502s as a fast worker (relevant context: ai-dock/comfyui-api-wrapper#10).
- The existing fatal-fault log line (``GPU on … latched as unrecoverable: …``) didn't carry a stable token, so ``MODEL_ERROR_LOG_MSGS`` couldn't pattern-match it. A truly broken backend stalled silently instead of surfacing to the autoscaler.

## What

Two structured log tokens for downstream consumers:

| Token | Level | When | Pyworker mapping |
|---|---|---|---|
| ``BACKENDS_READY`` | info | Once at startup, after every backend passes HTTP + WS probe | ``MODEL_LOAD_LOG_MSG`` (replaces \"Uvicorn running on\") |
| ``BACKENDS_READY_TIMEOUT`` | error | Backends never reachable within deadline | ``MODEL_ERROR_LOG_MSGS`` |
| ``BACKEND_UNRECOVERABLE`` | error | GPU latched (CUDA fault, illegal memory access, etc.) | ``MODEL_ERROR_LOG_MSGS`` |

## How

- New ``_probe_backend(urls)`` module-level helper, hoisted out of ``/health``'s nested ``_probe`` so the announcer and the endpoint share the same logic. ``/health`` behaviour unchanged.
- New ``_announce_backends_ready()`` async task, scheduled from ``startup_event`` alongside ``main()``. Polls every backend on a 2-second cadence until all pass HTTP+WS, capped at ``_BACKENDS_READY_TIMEOUT_S = 600`` to match ``convert-workflows.sh``'s ``COMFYUI_READY_TIMEOUT``. Emits exactly one of ``BACKENDS_READY`` / ``BACKENDS_READY_TIMEOUT``.
- ``mark_gpu_unrecoverable`` log message now starts with the ``BACKEND_UNRECOVERABLE:`` token. Same content, stable prefix.

## Tests

``tests/test_backends_ready_signal.py`` covers:
- All backends up immediately → ``BACKENDS_READY`` emitted, no timeout
- All backends down throughout the deadline → ``BACKENDS_READY_TIMEOUT`` emitted, no ready
- One backend slow to come up → announcer keeps polling, eventually emits ``BACKENDS_READY`` exactly once
- ``mark_gpu_unrecoverable`` log line carries the ``BACKEND_UNRECOVERABLE`` token

Full suite: 88/88 green.

## Test plan

- [x] Tests cover the three readiness paths and the fault-log token
- [ ] On a live worker: confirm ``BACKENDS_READY`` lands within seconds of uvicorn binding when ComfyUI is healthy
- [ ] Force a CUDA fault during generation; confirm ``BACKEND_UNRECOVERABLE`` appears in api-wrapper.log
- [ ] Pair with the matching pyworker change to switch ``MODEL_LOAD_LOG_MSG`` and ``MODEL_ERROR_LOG_MSGS``

🤖 Generated with [Claude Code](https://claude.com/claude-code)