### PR TITLE
Latch backend unrecoverable on persistent post-startup connectivity failure

### DIFF
--- a/tests/test_persistent_backend_fault.py
+++ b/tests/test_persistent_backend_fault.py
@@ -1,0 +1,120 @@
+"""Tests for the persistent-backend-fault classifier and counter.
+
+Background: a CUDA fault is caught by ``_detect_cuda_unrecoverable_reason``
+and immediately latches the backend. But ComfyUI also has plenty of
+non-CUDA ways to die (process killed by OOM-killer, deadlock, hang),
+which surface as ``Cannot connect to host`` / ``Failed to post
+workflow after N attempts``. Those used to leave the worker
+"healthy" from the SDK's view: requests fail with 502 but no fatal
+log token fires, so the autoscaler never replaces the pod.
+
+The fix counts connectivity-class failures per backend; once we've
+seen BACKEND_FAILURE_THRESHOLD consecutive ones, the backend is
+latched as unrecoverable (which emits ``BACKEND_UNRECOVERABLE`` for
+the pyworker to pick up). A single forward-progress success resets
+the counter so a brief restart blip doesn't accumulate.
+"""
+import logging
+
+import pytest
+
+from workers.generation_worker import (
+    BACKEND_FAILURE_THRESHOLD,
+    _BACKEND_FAILURE_COUNT,
+    _GPU_STATE,
+    _is_backend_connectivity_failure,
+    _record_backend_failure,
+    _record_backend_success,
+    get_gpu_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    _BACKEND_FAILURE_COUNT.clear()
+    _GPU_STATE.clear()
+    yield
+    _BACKEND_FAILURE_COUNT.clear()
+    _GPU_STATE.clear()
+
+
+_BACKEND = "http://b:18188"
+
+
+@pytest.mark.parametrize("text", [
+    "Cannot connect to host localhost:18188 ssl:default",
+    "Failed to post workflow after 5 attempts: ClientConnectorError",
+    "Network error getting result: ConnectionResetError",
+    "Connection refused",
+    "WebSocket timeout for job abc",
+    "Operation timed out after 30s",
+    # case insensitivity
+    "FAILED TO POST WORKFLOW AFTER 5 attempts",
+])
+def test_classifies_connectivity_failure(text):
+    assert _is_backend_connectivity_failure(text) is True
+
+
+@pytest.mark.parametrize("text", [
+    "ComfyUI node errors: KSampler.sampler_name not in list",
+    "ComfyUI error: bad input",
+    "torch.cuda.OutOfMemoryError",
+    "device-side assert triggered",
+    "",
+    None,
+])
+def test_skips_non_connectivity_text(text):
+    assert _is_backend_connectivity_failure(text) is False
+
+
+def test_below_threshold_does_not_latch():
+    """N-1 consecutive failures is not yet fatal."""
+    for _ in range(BACKEND_FAILURE_THRESHOLD - 1):
+        _record_backend_failure(_BACKEND, "Cannot connect")
+    assert get_gpu_state(_BACKEND)["unrecoverable"] is False
+
+
+def test_threshold_latches_backend_unrecoverable():
+    """Hitting the threshold latches the backend and surfaces a
+    BACKEND_UNRECOVERABLE log line."""
+    for _ in range(BACKEND_FAILURE_THRESHOLD):
+        _record_backend_failure(_BACKEND, "Cannot connect")
+    state = get_gpu_state(_BACKEND)
+    assert state["unrecoverable"] is True
+    assert "consecutive" in state["reason"].lower()
+
+
+def test_success_resets_counter():
+    """A successful workflow post on the same backend means it's alive
+    again — clear any prior connectivity-failure accumulation."""
+    for _ in range(BACKEND_FAILURE_THRESHOLD - 1):
+        _record_backend_failure(_BACKEND, "Cannot connect")
+    _record_backend_success(_BACKEND)
+    assert _BACKEND_FAILURE_COUNT.get(_BACKEND, 0) == 0
+    # And one more failure now starts a fresh count, doesn't latch.
+    _record_backend_failure(_BACKEND, "Cannot connect")
+    assert get_gpu_state(_BACKEND)["unrecoverable"] is False
+
+
+def test_threshold_latch_is_per_backend():
+    """A failed backend doesn't drag healthy ones down at the latch
+    level — but pod-level aggregation is still bad (any() in
+    get_gpu_state()), which is the desired worker-replacement signal."""
+    other = "http://other:18188"
+    for _ in range(BACKEND_FAILURE_THRESHOLD):
+        _record_backend_failure(_BACKEND, "Cannot connect")
+    assert get_gpu_state(_BACKEND)["unrecoverable"] is True
+    assert get_gpu_state(other)["unrecoverable"] is False
+    # Pod-level aggregation reports unhealthy because any() is bad.
+    assert get_gpu_state()["unrecoverable"] is True
+
+
+def test_latch_emits_grep_token(caplog):
+    """The latch path goes through mark_gpu_unrecoverable, which the
+    earlier change tagged with BACKEND_UNRECOVERABLE so pyworkers'
+    MODEL_ERROR_LOG_MSGS can match it."""
+    with caplog.at_level(logging.ERROR, logger="workers.generation_worker"):
+        for _ in range(BACKEND_FAILURE_THRESHOLD):
+            _record_backend_failure(_BACKEND, "Cannot connect")
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("BACKEND_UNRECOVERABLE" in m for m in msgs), msgs

--- a/workers/generation_worker.py
+++ b/workers/generation_worker.py
@@ -3,6 +3,7 @@ import asyncio
 import aiohttp
 import json
 import logging
+import os
 from typing import Optional, Dict, Any
 from datetime import datetime
 
@@ -33,6 +34,79 @@ logger = logging.getLogger(__name__)
 # `_attempt_oom_recovery()` calling that backend's `/free`.
 # ----------------------------------------------------------------------
 _GPU_STATE: Dict[str, Dict[str, Any]] = {}
+
+# Per-backend consecutive-failure counter for the "backend persistently
+# unreachable" path. Reset to zero on any successful workflow post.
+# When the count reaches BACKEND_FAILURE_THRESHOLD, that backend is
+# latched as unrecoverable — the assumption is that ComfyUI behind it
+# has died (process killed, hung, deadlocked) and the post_workflow
+# retry loop is no longer making progress, so the worker is useless
+# regardless of how many other backends are healthy.
+_BACKEND_FAILURE_COUNT: Dict[str, int] = {}
+
+# Hand-tuned default: low enough to fail fast on a truly dead backend,
+# high enough to absorb a brief restart blip during model swaps. Each
+# post_workflow attempt already retries 5x internally with linear
+# backoff, so this counter increments per *full* request-level
+# failure (i.e. retries already exhausted, or the failure happened
+# elsewhere in the generation flow).
+def _read_threshold() -> int:
+    raw = os.environ.get("BACKEND_FAILURE_THRESHOLD", "")
+    try:
+        n = int(raw)
+        return n if n > 0 else 3
+    except (TypeError, ValueError):
+        return 3
+
+BACKEND_FAILURE_THRESHOLD = _read_threshold()
+
+
+# Substrings that classify a generation-worker error as a backend
+# connectivity / liveness failure rather than a per-request issue.
+# Hits here count toward BACKEND_FAILURE_THRESHOLD; persistent hits
+# latch the backend as unrecoverable.
+_BACKEND_CONNECTIVITY_TRIGGERS = (
+    "cannot connect",
+    "failed to post workflow after",
+    "network error getting result",
+    "connection refused",
+    "websocket timeout",
+    "timed out",
+)
+
+
+def _is_backend_connectivity_failure(text: str) -> bool:
+    if not text:
+        return False
+    lowered = text.lower()
+    return any(t in lowered for t in _BACKEND_CONNECTIVITY_TRIGGERS)
+
+
+def _record_backend_failure(backend_url: str, reason: str) -> None:
+    """Increment the per-backend failure counter; latch as unrecoverable
+    once we've hit BACKEND_FAILURE_THRESHOLD consecutive failures."""
+    n = _BACKEND_FAILURE_COUNT.get(backend_url, 0) + 1
+    _BACKEND_FAILURE_COUNT[backend_url] = n
+    logger.warning(
+        "Backend %s connectivity failure %d/%d: %s",
+        backend_url, n, BACKEND_FAILURE_THRESHOLD, reason,
+    )
+    if n >= BACKEND_FAILURE_THRESHOLD:
+        mark_gpu_unrecoverable(
+            backend_url,
+            f"backend unreachable for {n} consecutive jobs ({reason})",
+        )
+
+
+def _record_backend_success(backend_url: str) -> None:
+    """Reset the per-backend failure counter on any forward progress.
+
+    A single successful post_workflow proves the backend is alive again,
+    so a brief blip during a model swap doesn't accumulate toward the
+    fatal threshold.
+    """
+    if _BACKEND_FAILURE_COUNT.get(backend_url, 0):
+        _BACKEND_FAILURE_COUNT[backend_url] = 0
 
 
 def mark_gpu_unrecoverable(backend_url: str, reason: str) -> None:
@@ -248,6 +322,16 @@ class GenerationWorker:
                     cuda_reason = _detect_cuda_unrecoverable_reason(error_message)
                     if cuda_reason:
                         mark_gpu_unrecoverable(self.backend_url, cuda_reason)
+                    elif _is_backend_connectivity_failure(error_message):
+                        # ComfyUI on this backend appears dead (process
+                        # crashed, hung, or otherwise unreachable). One
+                        # blip is fine — post_workflow already retries
+                        # 5x — but persistent failures across multiple
+                        # jobs mean the worker isn't doing what the
+                        # autoscaler expects. Latch unrecoverable once
+                        # we've seen BACKEND_FAILURE_THRESHOLD
+                        # consecutive failures.
+                        _record_backend_failure(self.backend_url, error_message)
 
                 try:
                     # Update result to show failure
@@ -379,6 +463,10 @@ class GenerationWorker:
                         response_data = json.loads(response_text)
 
                         if "prompt_id" in response_data:
+                            # Forward progress: any consecutive
+                            # connectivity failures on this backend
+                            # are clearly stale.
+                            _record_backend_success(self.backend_url)
                             return response_data["prompt_id"]
                         if "node_errors" in response_data:
                             error_details = json.dumps(response_data["node_errors"], indent=2)


### PR DESCRIPTION
## The gap

After ai-dock/comfyui-api-wrapper#11, a CUDA fault correctly emits ``BACKEND_UNRECOVERABLE`` and the pyworker propagates the failure to the autoscaler. But ComfyUI has plenty of non-CUDA ways to die — OOM-killer, deadlock, hang, segfault during model swap — which surface to us as ``Cannot connect to host`` or ``Failed to post workflow after 5 attempts: …``. Those used to leave the worker \"healthy\":

- ``post_workflow`` retries 5× with backoff and gives up.
- The job fails; ai-dock/comfyui-api-wrapper#10 makes the response a real 5xx so the SDK's benchmark sees a failure.
- But no fatal log token fires. The autoscaler never replaces the pod, so every subsequent request fails the same way and the operator sees a worker that's \"online but useless\".

## The fix

Per-backend consecutive-failure counter for the connectivity class.

- ``_record_backend_failure(url, reason)`` increments the count for that backend; once it hits ``BACKEND_FAILURE_THRESHOLD`` (default 3, env-tunable) it routes through ``mark_gpu_unrecoverable`` — so ``BACKEND_UNRECOVERABLE`` lands in the log just like a CUDA fault would, and the pyworker's ``MODEL_ERROR_LOG_MSGS`` matches it.
- ``_record_backend_success(url)`` resets the counter on any successful ``post_workflow``, so a brief restart blip during a model swap doesn't accumulate toward fatal.
- ``_is_backend_connectivity_failure(text)`` classifies error messages by substring against a small allow-list: ``cannot connect``, ``failed to post workflow after``, ``network error getting result``, ``connection refused``, ``websocket timeout``, ``timed out``.

### Wiring

- ``post_workflow``: on the ``prompt_id`` success branch, calls ``_record_backend_success(self.backend_url)``.
- GenerationWorker's outer exception handler: after the existing OOM and CUDA classifiers (so a CUDA-rooted timeout is correctly tagged CUDA, not generic connectivity), calls ``_record_backend_failure`` if the message classifies as connectivity.

### Per-backend vs. pod-level

The latch is per-backend, but ``get_gpu_state()`` already aggregates with ``any()`` — so in a multi-backend pod, a single dead backend marks the whole pod unhealthy. ``/health`` returns 503 and ``BACKEND_UNRECOVERABLE`` fires, and the autoscaler replaces the pod. Single-backend Vast deployments hit the same path trivially.

## Tests

``tests/test_persistent_backend_fault.py`` — 18 cases:

- 7 positives + 6 negatives for the classifier (case-insensitive substring match)
- below-threshold doesn't latch
- hitting threshold latches and the reason carries \"consecutive\"
- success resets the counter so the next failure starts fresh
- latch is per-backend; pod-level aggregation still bad
- log line carries the ``BACKEND_UNRECOVERABLE`` grep token

Full suite: 106/106 green.

## Test plan

- [x] Tests cover the classifier, counter, success-reset, per-backend isolation, and grep token
- [x] Full pytest run still green
- [ ] On a live worker: kill the ComfyUI process mid-stream, confirm 3 consecutive failed jobs latch the backend and ``BACKEND_UNRECOVERABLE`` reaches api-wrapper.log; confirm the pyworker marks the worker errored and the autoscaler replaces it

🤖 Generated with [Claude Code](https://claude.com/claude-code)