### PR TITLE
Populate Result.timings (queued / preprocess / generation / postprocess / total)

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,6 +118,39 @@ def _apply_base64_header(request: Request, payload):
         payload.input.return_outputs_as_base64 = True
 
 
+def _now_ms() -> int:
+    """Wall-clock milliseconds since the epoch.
+
+    Used to populate ``Result.timings``. Wall clock (not monotonic)
+    so the absolute timestamps are meaningful to the operator
+    reading a webhook / log payload, not just the per-stage deltas.
+    """
+    return int(time.time() * 1000)
+
+
+def _new_result(request_id: str) -> Result:
+    """Construct an initial Result with a queue-time timestamp stamped.
+
+    Each worker stage adds its own ``*_ms`` duration; ``postprocess_worker``
+    closes out ``completed_at_ms`` and ``total_ms`` when terminal
+    status is set, so ``timings`` ends up looking like::
+
+        {
+          "queued_at_ms":    1714... (epoch ms, set here),
+          "preprocess_ms":   42,
+          "generation_ms":   1480,
+          "postprocess_ms":  31,
+          "completed_at_ms": 1714... (epoch ms),
+          "total_ms":        1593,
+        }
+
+    The original goal is the queue→complete delta (``total_ms``);
+    the per-stage durations come along essentially for free since
+    every worker already brackets its own work block.
+    """
+    return Result(id=request_id, timings={"queued_at_ms": _now_ms()})
+
+
 # Substrings that classify a `failed` result.message as an upstream
 # connectivity / timeout problem (ComfyUI wasn't reachable, /prompt
 # retries exhausted, ws connection lost) rather than a generation
@@ -554,7 +587,7 @@ async def generate(
             message=f"Worker at capacity ({_MAX_QUEUE_SIZE} in flight); retry shortly",
         )
 
-    result_pending = Result(id=request_id)
+    result_pending = _new_result(request_id)
 
     try:
         # Store request and initial result
@@ -630,7 +663,7 @@ async def generate_sync(
             message=f"Worker at capacity ({_MAX_QUEUE_SIZE} in flight); retry shortly",
         )
 
-    result_pending = Result(id=request_id)
+    result_pending = _new_result(request_id)
     await request_store.set(request_id, payload)
     await response_store.set(request_id, result_pending)
 
@@ -677,7 +710,7 @@ async def generate_stream(
     request_id = payload.input.request_id
     _apply_base64_header(request, payload)
     
-    result_pending = Result(id=request_id)
+    result_pending = _new_result(request_id)
 
     # Backpressure (see /generate for rationale). Stream variant
     # raises HTTPException so FastAPI emits a JSON 503 instead of

--- a/tests/test_timings.py
+++ b/tests/test_timings.py
@@ -1,0 +1,90 @@
+"""Tests for the ``Result.timings`` end-to-end shape.
+
+The original goal is the queue→complete delta (``total_ms``) so SLO
+tracking works against real elapsed time. The per-stage durations
+(``preprocess_ms`` / ``generation_ms`` / ``postprocess_ms``) come
+along because every worker already brackets its own work block —
+they're useful when chasing where the time is going.
+
+The end-to-end stamping cuts across three workers and an endpoint,
+so most of the assertions here are unit-level: ``main._new_result``
+stamps ``queued_at_ms``, and ``postprocess_worker._close_out_timings``
+closes out ``postprocess_ms`` / ``completed_at_ms`` / ``total_ms`` on
+both success and failure paths.
+"""
+import time
+
+import pytest
+
+import main
+from responses.result import Result
+from workers.postprocess_worker import _close_out_timings
+
+
+def test_new_result_stamps_queued_at_ms():
+    before = int(time.time() * 1000)
+    r = main._new_result("req-x")
+    after = int(time.time() * 1000)
+    assert "queued_at_ms" in r.timings
+    assert before <= r.timings["queued_at_ms"] <= after
+
+
+def test_new_result_carries_only_queue_time_initially():
+    """preprocess / generation / postprocess fields land later, as
+    each worker fills its bracket. The initial Result must not lie
+    about durations it hasn't measured."""
+    r = main._new_result("req-x")
+    assert set(r.timings.keys()) == {"queued_at_ms"}
+
+
+def test_close_out_timings_populates_terminal_fields():
+    """postprocess closing out a successful run produces the full
+    timings dict the operator expects."""
+    r = main._new_result("req-x")
+    # Pretend each prior stage already measured itself.
+    r.timings["preprocess_ms"] = 10
+    r.timings["generation_ms"] = 1500
+    # Now postprocess runs for ~50ms.
+    pp_t0 = time.time() - 0.05
+    _close_out_timings(r, pp_t0)
+
+    assert "postprocess_ms" in r.timings
+    assert 40 <= r.timings["postprocess_ms"] <= 200, r.timings
+    assert "completed_at_ms" in r.timings
+    assert r.timings["completed_at_ms"] >= r.timings["queued_at_ms"]
+    assert "total_ms" in r.timings
+    assert r.timings["total_ms"] == (
+        r.timings["completed_at_ms"] - r.timings["queued_at_ms"]
+    )
+
+
+def test_close_out_timings_skips_total_when_queued_missing():
+    """Defensive: if ``queued_at_ms`` was never stamped (e.g. a
+    pre-timings Result deserialised from cache during a rolling
+    upgrade), we should record ``postprocess_ms`` and
+    ``completed_at_ms`` but not invent a bogus total."""
+    r = Result(id="r", timings={})  # no queued_at_ms
+    _close_out_timings(r, time.time() - 0.01)
+    assert "postprocess_ms" in r.timings
+    assert "completed_at_ms" in r.timings
+    assert "total_ms" not in r.timings
+
+
+def test_close_out_timings_runs_on_failure_path_too():
+    """Failed jobs still get total_ms — knowing how long a doomed
+    request was alive is just as useful as for a successful one."""
+    r = main._new_result("req-fail")
+    r.status = "failed"
+    r.timings["queued_at_ms"] = int(time.time() * 1000) - 200  # 200ms ago
+    pp_t0 = time.time() - 0.01
+    _close_out_timings(r, pp_t0)
+    assert r.timings["total_ms"] >= 150
+
+
+def test_timings_are_integers():
+    """Round to ms so downstream consumers don't have to deal with
+    floating-point JSON serialisation noise."""
+    r = main._new_result("req-x")
+    _close_out_timings(r, time.time() - 0.01)
+    for k, v in r.timings.items():
+        assert isinstance(v, int), f"{k}={v} ({type(v).__name__})"

--- a/workers/generation_worker.py
+++ b/workers/generation_worker.py
@@ -4,6 +4,7 @@ import aiohttp
 import json
 import logging
 import os
+import time
 from typing import Optional, Dict, Any
 from datetime import datetime
 
@@ -203,6 +204,11 @@ class GenerationWorker:
             # Process the job
             logger.info(f"GenerationWorker {self.worker_id} processing job: {request_id}")
 
+            # Stamp at the moment we commit to handling this job,
+            # *before* the store loads — we want to count store
+            # latency too if it ever becomes a thing.
+            generation_t0 = time.time()
+
             try:
                 # Get request and result from stores
                 request = await self.request_store.get(request_id)
@@ -287,6 +293,7 @@ class GenerationWorker:
                 # Update result with success
                 result.status = "generated"
                 result.message = "Generation complete. Queued for post-processing."
+                result.timings["generation_ms"] = int((time.time() - generation_t0) * 1000)
                 result.comfyui_response = comfyui_response
                 # Store execution details in the comfyui_response if needed
                 if execution_result:

--- a/workers/postprocess_worker.py
+++ b/workers/postprocess_worker.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import os  # Still needed for symlink and remove operations
 import shutil
+import time
 from pathlib import Path
 from typing import Dict, List, Optional
 import json
@@ -15,6 +16,37 @@ import aiohttp
 from config import OUTPUT_DIR, S3_CONFIG, S3_ENABLED, WEBHOOK_CONFIG, WEBHOOK_ENABLED
 
 logger = logging.getLogger(__name__)
+
+
+def _close_out_timings(result, postprocess_t0: float) -> None:
+    """Stamp ``postprocess_ms`` and the terminal ``completed_at_ms`` /
+    ``total_ms`` fields on ``result.timings``.
+
+    Called on both success and failure paths in postprocess so the
+    queue→complete delta is recorded regardless of outcome.
+    ``queued_at_ms`` was set when the request was first stored
+    (``main._new_result``); when it's missing for some reason we
+    skip ``total_ms`` rather than computing nonsense.
+
+    Tolerates an absent or None ``timings`` attribute — the postprocess
+    loop has been seen entering with bare stand-in objects (e.g. when
+    ``request_store`` was rebuilt during a rolling upgrade), and a
+    crash here would propagate out of ``work()`` and drain the worker
+    pool.
+    """
+    now_ms = int(time.time() * 1000)
+    timings = getattr(result, "timings", None) or {}
+    timings["postprocess_ms"] = int((time.time() - postprocess_t0) * 1000)
+    timings["completed_at_ms"] = now_ms
+    queued = timings.get("queued_at_ms")
+    if queued:
+        timings["total_ms"] = now_ms - queued
+    try:
+        result.timings = timings
+    except (AttributeError, TypeError):
+        # Read-only / slotted result object — record-keeping is
+        # best-effort, never block the request on it.
+        pass
 
 
 class PostprocessWorker:
@@ -48,6 +80,11 @@ class PostprocessWorker:
             # unbound name if `request_store.get` itself raises.
             request = None
             result = None
+
+            # Stamp at the moment we commit to handling this job; the
+            # ms duration plus completed_at_ms / total_ms get committed
+            # to result.timings just before final write.
+            postprocess_t0 = time.time()
 
             try:
                 # Get request and result from stores
@@ -90,21 +127,32 @@ class PostprocessWorker:
                     result.message = "Processing complete."
                 else:
                     logger.info(f"Job {request_id} already marked as failed, keeping failure status")
-                
+
+                # Close out timings on the terminal write. total_ms is
+                # the queue→complete metric requested for SLO tracking;
+                # stage *_ms come along since each worker brackets its
+                # own block.
+                _close_out_timings(result, postprocess_t0)
+
                 await self.response_store.set(request_id, result)
                 logger.info(f"PostprocessWorker {self.worker_id} completed job: {request_id}")
                 
             except Exception as e:
                 logger.error(f"PostprocessWorker {self.worker_id} failed job {request_id}: {e}")
-                
+
                 try:
                     # Update result to show failure
                     result = await self.response_store.get(request_id)
                     if result:
                         result.status = "failed"
                         result.message = f"Post-processing failed: {str(e)}"
+                        # Failed jobs still want timings — total_ms is
+                        # how long the request was alive end-to-end,
+                        # which is a useful SLO signal regardless of
+                        # success.
+                        _close_out_timings(result, postprocess_t0)
                         await self.response_store.set(request_id, result)
-                    
+
                 except Exception as store_error:
                     logger.error(f"Failed to update result store for {request_id}: {store_error}")
             

--- a/workers/preprocess_worker.py
+++ b/workers/preprocess_worker.py
@@ -1,6 +1,8 @@
 # preprocess_worker
 import importlib
 import logging
+import time
+
 from modifiers.basemodifier import BaseModifier
 
 logger = logging.getLogger(__name__)
@@ -46,23 +48,28 @@ class PreprocessWorker:
                     await self.postprocess_queue.put(request_id)
                     self.preprocess_queue.task_done()
                     continue
-                
+
+                # Stamp preprocess start; ms duration is committed to
+                # result.timings before we hand off to generation.
+                preprocess_t0 = time.time()
+
                 # Get and initialize the workflow modifier
                 modifier = await self.get_workflow_modifier(
-                    request.input.modifier, 
+                    request.input.modifier,
                     request.input.modifications
                 )
-                
+
                 # Load and modify the workflow
                 await modifier.load_workflow(request.input.workflow_json)
                 request.input.workflow_json = await modifier.get_modified_workflow()
-                
+
                 # Update the request store with modified workflow
                 await self.request_store.set(request_id, request)
-                
+
                 # Update result status to show preprocessing is complete
                 result.status = "processing"
                 result.message = "Preprocessing complete. Queued for generation."
+                result.timings["preprocess_ms"] = int((time.time() - preprocess_t0) * 1000)
                 await self.response_store.set(request_id, result)
                 
                 # Send for ComfyUI generation


### PR DESCRIPTION
## Why

The ``Result`` schema declared ``timings: Dict = Field(default={})`` and the webhook envelope already forwarded it, but nothing was populating it — every result over the wire had ``timings: {}``, losing the queue→complete metric the field was added for. The original goal was SLO tracking on \"time from queued to completed\".

## What

Stamp wall-clock ms across the pipeline:

| Stage | Field | Where |
|---|---|---|
| Endpoint accepts request | ``queued_at_ms`` | ``main._new_result(request_id)`` (used by all 3 submission paths) |
| Preprocess work | ``preprocess_ms`` | ``PreprocessWorker`` bracket |
| Generation work (post→history) | ``generation_ms`` | ``GenerationWorker`` bracket |
| Postprocess work | ``postprocess_ms`` | ``PostprocessWorker`` bracket |
| Final terminal write | ``completed_at_ms``, ``total_ms`` | ``_close_out_timings`` in postprocess |

``total_ms = completed_at_ms - queued_at_ms`` is the requested queue→complete metric. The per-stage ``*_ms`` fields come along essentially for free since each worker already brackets its own work block, and they're useful when chasing where the time is going.

Failed jobs still get ``total_ms`` — knowing how long a doomed request was alive is just as useful as for a successful one. ``_close_out_timings`` tolerates a missing/None ``timings`` attribute and read-only result objects so a record-keeping bug can't drain the worker pool (the ``test_postprocess_survives_missing_request`` regression test caught this on first run with a bare stub object).

## Wire shape

```json
{
  \"id\": \"abc-123\",
  \"status\": \"completed\",
  \"output\": [...],
  \"comfyui_response\": {...},
  \"timings\": {
    \"queued_at_ms\":    1715175600000,
    \"preprocess_ms\":   42,
    \"generation_ms\":   1480,
    \"postprocess_ms\":  31,
    \"completed_at_ms\": 1715175601553,
    \"total_ms\":        1553
  }
}
```

Wall-clock (``time.time()``) rather than monotonic so the absolute timestamps are meaningful in webhooks / logs, not just the deltas. Clock skew during a single request would mis-report by a small amount, which is acceptable for these metrics.

## Tests

``tests/test_timings.py`` — 6 cases: ``_new_result`` stamps only ``queued_at_ms``; ``_close_out_timings`` populates terminal fields on success and failure paths; defensive when ``queued_at_ms`` is missing (rolling upgrade scenario); rounded to ints (no float JSON noise). Full suite 112/112.

## Test plan

- [x] Tests cover initial stamp, terminal close-out, success/failure, defensive missing-queued-at, integer rounding
- [x] Existing ``test_postprocess_survives_missing_request`` still passes (defensive helper passed the bare-stub it threw at us)
- [ ] On a live worker: submit a job, confirm the response carries a real ``total_ms`` matching the visible request latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)